### PR TITLE
added unreviewed but likely negative flagellar motor samples function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,0 @@
-tomogram_datasets.egg-info/
-.gitignore
-__pycache__/
-py_tomogram_datasets/
-j/
-k/
-debug.py

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ tomogram_datasets.egg-info/
 __pycache__/
 py_tomogram_datasets/
 j/
+k/
+debug.py

--- a/answering_questions.ipynb
+++ b/answering_questions.ipynb
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -44,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -345,6 +345,106 @@
    "metadata": {},
    "outputs": [],
    "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### How many motors do our annotated tomograms have?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "motors = []\n",
+    "for tomo in all_tomos:\n",
+    "    annotations = tomo.annotation_points()\n",
+    "    motors.append(len(annotations))\n",
+    "\n",
+    "values = plt.hist(motors, align=\"left\")\n",
+    "plt.title(f\"Number of motors in annotated tomograms (N = {len(all_tomos)})\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(max(motors))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "I want to see the tomogram with 10 motors!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cool_tomo_index = np.argmax(motors)\n",
+    "cool_tomo = all_tomos[cool_tomo_index]\n",
+    "cool_tomo.load();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from skimage import exposure \n",
+    "\n",
+    "def process_tomogram(data):\n",
+    "    \"\"\" Simple tomogram processing - uses contrast stretching to improve contrast. \"\"\"\n",
+    "    # Contrast stretching\n",
+    "    p2, p98 = np.percentile(data, (2, 98))\n",
+    "    data_rescale = exposure.rescale_intensity(data, in_range=(p2, p98))\n",
+    "    return data_rescale\n",
+    "\n",
+    "data = process_tomogram(cool_tomo.data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "visualize(data, marks=cool_tomo.annotation_points(), slices=100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Percentage of annotated tomograms with one motor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"{motors.count(1) / len(motors) * 100:.2f}%\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -363,7 +463,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.5"
+   "version": "3.9.18"
   }
  },
  "nbformat": 4,

--- a/debug.py
+++ b/debug.py
@@ -1,3 +1,8 @@
 from tomogram_datasets import all_fm_tomograms
+from tomogram_datasets import all_fm_negative_tomograms
 
-tomos = all_fm_tomograms()
+neg_tomos = all_fm_negative_tomograms()
+pos_tomos = all_fm_tomograms()
+
+for tomo in neg_tomos:
+    print(tomo.filepath)

--- a/tomogram_datasets/supercomputer_utils.py
+++ b/tomogram_datasets/supercomputer_utils.py
@@ -10,6 +10,8 @@ from .tomogram import TomogramFile
 
 from typing import List, Union, Optional
 
+import warnings
+
 def all_fm_tomograms() -> List[TomogramFile]:
     """Collect all pairs of `.rec` tomogram filepaths and flagellar motor `.mod` filepaths.
 
@@ -150,7 +152,143 @@ def all_fm_tomograms() -> List[TomogramFile]:
     tomograms += these_tomograms
     
     return tomograms
+
+def all_fm_negative_tomograms() -> List[TomogramFile]:
+    """
+    Collect all `.rec` tomogram filepaths that have (probably, for now) been
+    reviewed and do not have flagellar motors.
+
+    **IN DEVELOPMENT**
+
+    Returns:
+        TomogramFile objects with no annotations attached.
+    """
+    tomograms = []
     
+    # ~~~ DRIVE 1 ~~~ #
+    # Hylemonella
+    root = f"/grphome/grp_tomo_db1_d1/nobackup/archive/TomoDB1_d1/FlagellarMotor_P1/Hylemonella gracilis"
+    dir_regex = re.compile(r"yc\d{4}.*")
+    directories = seek_dirs(root, dir_regex)
+    
+    flagellum_regex = re.compile(r"^fm.mod$", re.IGNORECASE)
+    tomogram_regex = re.compile(r".*\.rec$")
+    
+    these_tomograms = seek_unannotated_tomos(
+        directories, 
+        tomogram_regex, 
+        [flagellum_regex]
+    )
+    tomograms += these_tomograms
+
+    # ~~~ DRIVE 2 ~~~ #
+    # Legionella
+    root = f"/grphome/grp_tomo_db1_d2/nobackup/archive/TomoDB1_d2/FlagellarMotor_P2/legionella"
+    dir_regex = re.compile(r"dg\d{4}.*")
+    directories = seek_dirs(root, dir_regex)
+    
+    flagellum_regex = re.compile(r"^FM\.mod$")
+    tomogram_regex = re.compile(r".*SIRT_1k\.rec$")
+    
+    these_tomograms = seek_unannotated_tomos(
+        directories, 
+        tomogram_regex, 
+        [flagellum_regex]
+    )
+    tomograms += these_tomograms
+
+    # Pseudomonas
+    root = f"/grphome/grp_tomo_db1_d2/nobackup/archive/TomoDB1_d2/FlagellarMotor_P2/Pseudomonasaeruginosa/done"
+    dir_regex = re.compile(r"ab\d{4}.*")
+    directories = seek_dirs(root, dir_regex)
+    
+    flagellum_regex = re.compile(r"^FM\.mod$")
+    tomogram_regex = re.compile(r".*SIRT_1k\.rec$")
+    
+    these_tomograms = seek_unannotated_tomos(
+        directories, 
+        tomogram_regex, 
+        [flagellum_regex]
+    )
+    tomograms += these_tomograms
+
+    # Proteus_mirabilis
+    root = f"/grphome/grp_tomo_db1_d2/nobackup/archive/TomoDB1_d2/FlagellarMotor_P2/Proteus_mirabilis"
+    dir_regex = re.compile(r"qya\d{4}.*")
+    directories = seek_dirs(root, dir_regex)
+    
+    flagellum_regex = re.compile(r"^FM\.mod$")
+    tomogram_regex = re.compile(r".*\.rec$")
+    
+    these_tomograms = seek_unannotated_tomos(
+        directories, 
+        tomogram_regex, 
+        [flagellum_regex]
+    )
+    tomograms += these_tomograms
+
+    # ~~~ DRIVE 3 ~~~ #
+    # Bdellovibrio
+    root = f"/grphome/grp_tomo_db1_d3/nobackup/archive/TomoDB1_d3/jhome_extra/Bdellovibrio_YW"
+    dir_regex = re.compile(r"yc\d{4}.*")
+    directories = seek_dirs(root, dir_regex)
+    
+    flagellum_regex = re.compile(r"^flagellum_SIRT_1k\.mod$")
+    tomogram_regex = re.compile(r".*SIRT_1k\.rec$")
+    
+    these_tomograms = seek_unannotated_tomos(
+        directories, 
+        tomogram_regex, 
+        [flagellum_regex]
+    )
+    tomograms += these_tomograms
+
+    # Azospirillum
+    root = f"/grphome/grp_tomo_db1_d3/nobackup/archive/TomoDB1_d3/jhome_extra/AzospirillumBrasilense/done"
+    dir_regex = re.compile(r"ab\d{4}.*")
+    directories = seek_dirs(root, dir_regex)
+    
+    flagellum_regex = re.compile(r"^FM3\.mod$")
+    tomogram_regex = re.compile(r".*SIRT_1k\.rec$")
+    
+    these_tomograms = seek_unannotated_tomos(
+        directories, 
+        tomogram_regex, 
+        [flagellum_regex]
+    )
+    tomograms += these_tomograms
+
+    # ~~~ ZHIPING ~~~ #
+    root = f"/grphome/fslg_imagseg/nobackup/archive/zhiping_data/caulo_WT/"
+    dir_regex = re.compile(r"rrb\d{4}.*")
+    directories = seek_dirs(root, dir_regex)
+    
+    flagellum_regex = re.compile(r"^flagellum\.mod$")
+    tomogram_regex = re.compile(r".*\.rec$")
+    
+    these_tomograms = seek_unannotated_tomos(
+        directories, 
+        tomogram_regex, 
+        [flagellum_regex]
+    )
+    tomograms += these_tomograms
+
+    # ~~~ ANNOTATION PARTY ~~~ #
+    root = f"/grphome/grp_tomo_db1_d4/nobackup/archive/ExperimentRuns/"
+    dir_regex = re.compile(r"(sma\d{4}.*)|(Vibrio.*)")
+    directories = seek_dirs(root, dir_regex)
+
+    flagellum_regex = re.compile(r"flagellar_motor\.mod")
+    tomogram_regex = re.compile(r".*\.mrc$")
+
+    these_tomograms = seek_unannotated_tomos(
+        directories, 
+        tomogram_regex, 
+        [flagellum_regex]
+    )
+    tomograms += these_tomograms
+    
+    return tomograms
 
 
 def seek_file(directory: str, regex: re.Pattern) -> Union[str, None]:
@@ -273,7 +411,9 @@ def seek_annotated_tomos(
             annotation_regexes: List[re.Pattern], 
             annotation_names: List[str]
         ) -> List[TomogramFile]:
-    """Collect pairs of tomogram files and their corresponding annotation files.
+    """
+    Collect pairs of tomogram files and their corresponding annotation files,
+    without loading the tomograms.
 
     Args:
         directories (list of str): List of directories to search for tomograms
@@ -287,8 +427,7 @@ def seek_annotated_tomos(
         annotation_names (list of str): A list of names for the annotations.
 
     Returns:
-        TomogramFile objects with their corresponding
-        annotations.
+        TomogramFile objects with their corresponding annotations.
     """
     tomos = []
     for dir in directories:
@@ -304,4 +443,54 @@ def seek_annotated_tomos(
                     print(f"An exception occured while loading `{file}`:\n{e}\n")
             tomo = TomogramFile(tomogram_file, annotations, load=False)
             tomos.append(tomo)
+    return tomos
+
+def seek_unannotated_tomos(
+            directories: List[str], 
+            tomo_regex: re.Pattern, 
+            annotation_regexes: List[re.Pattern], 
+        ) -> List[TomogramFile]:
+    """
+    Collect tomogram files that don't have annotations, without loading the
+    tomograms.
+
+    Args:
+        directories (list of str): List of directories to search for tomograms
+        and annotations.
+        
+        tomo_regex (re.Pattern): The regex pattern to match tomogram filenames.
+        
+        annotation_regexes (list of re.Pattern): A list of regex patterns. If
+        any of these patterns find a match for one of the files in a given
+        directory in `directories`, the tomogram in that directory will not be
+        saved and returned. 
+
+    Returns:
+        TomogramFile objects.
+    """
+    tomos = []
+    for dir in directories:
+        matches = seek_set(dir, [tomo_regex] + annotation_regexes)
+
+        if matches is not None and None not in matches:
+            # This tomogram is annotated
+            continue
+        else:
+            # Ensure that there is a tomogram in this directory
+            tomo_candidates = seek_files(dir, tomo_regex)
+            n_candidates = len(tomo_candidates)
+            # If there are multiple possible unannotated tomogram candidates or
+            # none here, that's an issue.
+            if n_candidates > 1:
+                warnings.warn(f"Multiple ({n_candidates}) unannotated tomograms in {dir} found. This may mean that the regular expression used to seek tomograms is not specific enough, or that this directory is strange.")
+                continue
+            elif n_candidates == 0:
+                warnings.warn(f"No tomograms found in {dir}.")
+                continue
+            # If there is one candidate, it isn't annotated.
+            else:
+                # Append what must be the only unannotated tomogram candidate
+                tomogram_file = tomo_candidates[0]
+                tomo = TomogramFile(tomogram_file, load=False)
+                tomos.append(tomo) 
     return tomos


### PR DESCRIPTION
Added `all_fm_negative_tomograms()` in `supercomputer_utils.py` along with a couple extra bits to make it work. It just looks through directories that `all_fm_tomograms` also parses for positive samples, and if there isn't a positive sample, saves it as a negative sample. 

The output will undoubtedly need to be manually reviewed and refined.